### PR TITLE
remove response logging

### DIFF
--- a/src/DHT_c.c
+++ b/src/DHT_c.c
@@ -163,14 +163,14 @@ int readDHT()
     // == DHT will keep the line low for 80 us and then high for 80us ====
 
     uSec = getSignalLevel(85, 0);
-    ESP_LOGD(TAG, "Response = %d", uSec);
+ //   ESP_LOGD(TAG, "Response = %d", uSec);
     if (uSec < 0)
         return DHT_TIMEOUT_ERROR;
 
     // -- 80us up ------------------------
 
     uSec = getSignalLevel(85, 1);
-    ESP_LOGD(TAG, "Response = %d", uSec);
+ //   ESP_LOGD(TAG, "Response = %d", uSec);
     if (uSec < 0)
         return DHT_TIMEOUT_ERROR;
 


### PR DESCRIPTION
These logs were messing up the timing of reading the data from the sensor, and I was getting Sensor Timeout errors.
Removing these logs solved the issue.